### PR TITLE
机因中显示被@的内容的时候保持刮刮卡显示

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -612,7 +612,11 @@
                                 }
                                 // 输出
                                 if (outputID !== -1) {
-                                    const replyContentsText = allSource.eq(outputID).text();
+                                    const replyContentHtml = allSource.eq(outputID).clone();
+                                    replyContentHtml.find('.mark').text(function(index, text) {
+                                        return text.replace(/./g,'█');
+                                    });
+                                    const replyContentsText = replyContentHtml.text();
                                     const replyContents = replyContentsText.length > 45
                                         ? `${replyContentsText.substring(0, 45)}......`
                                         : replyContentsText;

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -613,13 +613,30 @@
                                 // 输出
                                 if (outputID !== -1) {
                                     const replyContentHtml = allSource.eq(outputID).clone();
-                                    replyContentHtml.find('.mark').text(function(index, text) {
+                                    replyContentHtml.find('.mark').text(function (index, text) {
                                         return `<span class="mark">${text}</span>`;
                                     });
-                                    const replyContentsText = replyContentHtml.text();
-                                    const replyContents = replyContentsText.length > 45
-                                        ? `${replyContentsText.substring(0, 45)}......`
-                                        : replyContentsText;
+                                    const replyContentsText = replyContentHtml.text().split('');
+                                    let contentsLength = 0;
+                                    let isCount = true;
+                                    let replyContents = [];
+                                    for (let i = 0; i < replyContentsText.length; i++) {
+                                        if (replyContentsText[i] === '<') {
+                                            isCount = false;
+                                        }
+                                        if (replyContentsText[i] === '>') {
+                                            isCount = true;
+                                            contentsLength -= 1;
+                                        }
+                                        if (isCount) {
+                                            contentsLength++;
+                                        }
+                                        replyContents.push(replyContentsText[i])
+                                        if (contentsLength > 45) {
+                                            replyContents.push('......');
+                                            break;
+                                        }
+                                    }
                                     const avatorImg = avator.eq(outputID).find('img:eq(0)').attr('src');
                                     allSource.eq(floor).before(`
                                         <div class=replyTraceback>
@@ -628,13 +645,13 @@
                                                     ${linkContent[1]}
                                             </span>
                                             <span class="responserContent_${floor}_${outputID}" style="padding-left: 10px;">
-                                                ${replyContents}
+                                                ${replyContents.join('')}
                                             </span>
                                         </div>`);
                                     // 如果内容超过45个字符，则增加悬浮显示全文内容功能
-                                    replyContentsText.length > 45
+                                    contentsLength > 45
                                         ? tippy(`.responserContent_${floor}_${outputID}`, {
-                                            content: replyContentsText,
+                                            content: replyContents.join(''),
                                             animateFill: false,
                                             maxWidth: '500px',
                                         })

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -614,7 +614,7 @@
                                 if (outputID !== -1) {
                                     const replyContentHtml = allSource.eq(outputID).clone();
                                     replyContentHtml.find('.mark').text(function(index, text) {
-                                        return text.replace(/./g,'█');
+                                        return `<span class="mark">${text}</span>`;
                                     });
                                     const replyContentsText = replyContentHtml.text();
                                     const replyContents = replyContentsText.length > 45

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -653,7 +653,7 @@
                                 }
                                 // 输出
                                 if (outputID !== -1) {
-                                    const replyContentObject = allSource.eq(outputID);
+                                    const replyContentObject = allSource.eq(outputID).clone();
                                     const replyContentPlainText = replyContentObject.text();
                                     replyContentObject.find('.mark').text(function (index, text) {
                                         return `<span class="mark">${text}</span>`;

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      0.9.40
+// @version      0.9.41
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
 // @author       InfinityLoop, mordom0404, Nathaniel_Wu, JayusTree


### PR DESCRIPTION
#69 理论上原来是刮刮卡的内容，在回复中依然显示成刮刮卡最好。
但是因为还有45个字的省略条件，以及鼠标悬浮显示全部内容，导致了边界条件判断起来很困难。
本人不是专业前端 JS 水平又差，只能先用这种替换方式，让用户直接去看原内容剧透比较好。