### PR TITLE
[fix] misplaced QA status icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.1
+// @version      1.0.2
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
@@ -1030,9 +1030,9 @@
           // 替换文字状态为图标形式
           const selector = 'div.ml64>p.title.font16>a';
           switch (status) {
-            case '已解决': $(node).find(selector).append('<div class="fa-check-circle"></div>'); break;
-            case '未回答': $(node).find(selector).append('<div class="fa-question-circle"></div>'); break;
-            case '解决中': $(node).find(selector).append('<div class="fa-comments"></div>'); break;
+            case '已解决': $(node).find(selector).prepend('<div class="fa-check-circle"></div>'); break;
+            case '未回答': $(node).find(selector).prepend('<div class="fa-question-circle"></div>'); break;
+            case '解决中': $(node).find(selector).prepend('<div class="fa-comments"></div>'); break;
             default: return;
           }
           const elReward = $(node).find('div.meta > .r > span:nth-child(1)');


### PR DESCRIPTION
问答的标题比较长、需要占用两行及以上的时候，状态标志会跟最后一行对齐。

Before:
<img width="810" alt="before" src="https://user-images.githubusercontent.com/7333103/120388300-ec799100-c2f8-11eb-9579-f6e683be5457.png">
After:
<img width="810" alt="after" src="https://user-images.githubusercontent.com/7333103/120388307-f0a5ae80-c2f8-11eb-88fe-aae9baac550c.png">