### PR TITLE
Fix the issue where http resources are used on https pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -910,7 +910,7 @@
       // 站内使用HTTPS链接
       const fixHTTPLinksOnThePage = (isOn) => {
         if (isOn) {
-          $("a[href*='http://psnine.com'], a[href*='http://www.psnine.com'], link[href*='http://psnine.com'], link[href*='http://www.psnine.com']").each((i, a) => linkReplace(a, 'http://', 'https://'));
+          $("a[href*='http://psnine.com'], a[href*='http://www.psnine.com'], link[href*='http://psnine.com'], link[href*='http://www.psnine.com'], img[src*='http://psnine.com'], img[src*='http://www.psnine.com']").each((i, a) => linkReplace(a, 'http://', 'https://'));
           const scriptSources = [];
           $("script[src*='http://psnine.com'], script[src*='http://www.psnine.com']").each((i, s) => {
             scriptSources.push(s.src.replace('http://', 'https://'));

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.2
+// @version      1.0.3
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
@@ -892,9 +892,11 @@
       };
       // 修复D7VG链接
       const linkReplace = (link, substr, newSubstr) => {
-        link.href = (link.href === link.innerText)
-          ? (link.innerText = link.innerText.replace(substr, newSubstr))
-          : link.href.replace(substr, newSubstr);
+        if (link.href) {
+          link.href = (link.href === link.innerText)
+            ? (link.innerText = link.innerText.replace(substr, newSubstr))
+            : link.href.replace(substr, newSubstr);
+        } else if (link.src) link.src = link.src.replace(substr, newSubstr);
       };
       const fixD7VGLinksOnThePage = (isOn) => {
         if (isOn) {
@@ -906,7 +908,7 @@
         }
       };
       // 站内使用HTTPS链接
-      const fixHTTPLinksOnThePage = (isOn) => { if (isOn) $("a[href*='http://psnine.com'], a[href*='http://www.psnine.com']").each((i, a) => linkReplace(a, 'http://', 'https://')); };
+      const fixHTTPLinksOnThePage = (isOn) => { if (isOn) $("a[href*='http://psnine.com'], a[href*='http://www.psnine.com'], link[href*='http://psnine.com'], link[href*='http://www.psnine.com'], script[src*='http://psnine.com'], script[src*='http://www.psnine.com']").each((i, a) => linkReplace(a, 'http://', 'https://')); };
       fixTextLinksOnThePage(settings.fixTextLinks);
       fixD7VGLinksOnThePage(settings.fixD7VGLinks);
       fixHTTPLinksOnThePage(settings.fixHTTPLinks);


### PR DESCRIPTION
最近P9后台改动的缺陷导致HTTPS页面在大部分浏览器的默认安全策略下都不能正常显示，反馈了近一周了也没改，先自己强行修复一下。