### PR TITLE
修复评论分数趋势图相关问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "psnine-enhanced-version",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -2567,9 +2567,9 @@
             crosshair: true,
           }];
           const scoreYaxis = [{
-            tickInterval: gaussianOn ? 2 : 1,
             min: 0,
-            max: scoreCountMax,
+            max: 5 * Math.ceil(scoreCountMax / 5),
+            tickInterval: Math.ceil(scoreCountMax / 5),
             title: { text: '点评人数' },
           }];
           const scoreTooltip = {


### PR DESCRIPTION
1. 某些老游戏页面评论时间戳解析不正确。（例：[https://psnine.com/psngame/4712/comment](https://psnine.com/psngame/4712/comment)）
2. Highcharts新版本在一定条件下生成的图表Y轴tick过于密集。（例：[https://psnine.com/psngame/20919/comment](https://psnine.com/psngame/20919/comment)、[https://www.psnine.com/psngame/16758/comment](https://www.psnine.com/psngame/16758/comment)）