### PR TITLE
[fix] enable replyTraceback on game comment pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.10
+// @version      1.0.11
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
@@ -635,6 +635,9 @@
     */
     const showReplyContent = (isOn) => {
       if (isOn) {
+        // 每一层楼的回复框
+        const allSource = $('.post .ml64 > .content');
+        if (allSource.length <= 0) return;
         GM_addStyle(
           `.replyTraceback {
                         background-color: rgb(0, 0, 0, 0.05) !important;
@@ -649,8 +652,6 @@
                         text-align: left;
                         overflow-wrap: break-word;
                     }`);
-        // 每一层楼的回复框
-        const allSource = $('.post .ml64 > .content');
         // 每一层楼的回复者用户名
         const userId = $('.post > .ml64 > [class$=meta]');
         // 每一层的头像
@@ -1781,9 +1782,7 @@
       addInputPreview("textarea[name='content']");
     }
     // 页面：机因、主题
-    if (
-      /(gene|topic|trade|battle)\//.test(window.location.href)
-    ) {
+    if (/\/((gene|topic|trade|battle)\/)|(psngame\/\d+\/comment\/?$)/.test(window.location.href)) {
       showReplyContent(settings.replyTraceback);
     }
     // 页面：问答


### PR DESCRIPTION
注意到比较老的游戏的评论页面并非使用层内回复，有必要打开replyTraceback。
测试页面：[https://psnine.com/psngame/3001/comment](https://psnine.com/psngame/3001/comment), [https://psnine.com/psngame/5254/comment](https://psnine.com/psngame/5254/comment)