### PR TITLE
添加  “在游戏列表中为自己100%完成的游戏添加背景色” 功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -430,7 +430,6 @@
         }`);
 
       // 背景 CSS 进度条计算，含夜间模式
-
       const progressPlatinumBG = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.6) ${p}%, rgba(200,255,250,0.15) ${p}%)`;
       const progressPlatinumBGNight = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.15) ${p}%, rgba(200,255,250,0.05) ${p}%)`;
       const progressGoldBG = (p) => `background-image: linear-gradient(90deg, rgba(220,255,220,0.8) ${p}%, rgba(220,255,220,0.15) ${p}%);`;
@@ -440,32 +439,28 @@
 
       // 根据已保存的完成度添加染色
       const personalGameCompletions = GM_getValue('personalGameCompletions', []);
+
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
+        const gameHasPlatinum = tr.querySelector('td.pd10 > .meta > em.text-platinum').textContent === '白1';
+        // if game hase platinum 由于个人页面的白金判断是记录的个人完成度，这里需要判断游戏本身是否有白金
+
         if (thisGameCompletion) {
-          // if game hase platinum
-          if (tr.querySelector('td.pd10 > .meta > em.text-platinum').textContent === '白1') {
-            if (settings.nightMode) {
-              tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1]));
-            } else {
-              tr.setAttribute('style', progressPlatinumBG(thisGameCompletion[1]));
-            }
-          } else if (settings.nightMode) {
-            tr.setAttribute('style', progressGoldBGNight(thisGameCompletion[1]));
-          } else {
-            tr.setAttribute('style', progressGoldBG(thisGameCompletion[1]));
-          }
-          // 添加进度徽章
-          const gameText = tr.querySelector('td.pd10 > p > a');
-          if (gameText) {
-            const completion = thisGameCompletion[1];
-            const completionBadge = document.createElement('span');
-            completionBadge.className = 'completion-badge';
-            completionBadge.textContent = `${completion}%`;
-            completionBadge.title = '奖杯完成度';
-            gameText.parentNode.insertBefore(completionBadge, gameText);
-          }
+          if (gameHasPlatinum && settings.nightMode) { tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1])); }
+          if (gameHasPlatinum && !settings.nightMode) { tr.setAttribute('style', progressPlatinumBG(thisGameCompletion[1])); }
+          if (!gameHasPlatinum && settings.nightMode) { tr.setAttribute('style', progressGoldBGNight(thisGameCompletion[1])); }
+          if (!gameHasPlatinum && !settings.nightMode) { tr.setAttribute('style', progressGoldBG(thisGameCompletion[1])); }
+        }
+        // 添加进度徽章
+        const gameText = tr.querySelector('td.pd10 > p > a');
+        if (gameText) {
+          const completion = thisGameCompletion[1];
+          const completionBadge = document.createElement('span');
+          completionBadge.className = 'completion-badge';
+          completionBadge.textContent = `${completion}%`;
+          completionBadge.title = '奖杯完成度';
+          gameText.parentNode.insertBefore(completionBadge, gameText);
         }
       });
 

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -463,7 +463,6 @@
 
       // 为 span 元素添加点击排序功能
       spanElement.addEventListener('click', () => {
-
         const tdArray = Array.from(tdElements).map((tr) => {
           const valueElement = tr.querySelector('td.twoge > em');
           const value = valueElement ? parseFloat(valueElement.textContent) : null;

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -451,16 +451,16 @@
           if (gameHasPlatinum && !settings.nightMode) { tr.setAttribute('style', progressPlatinumBG(thisGameCompletion[1])); }
           if (!gameHasPlatinum && settings.nightMode) { tr.setAttribute('style', progressGoldBGNight(thisGameCompletion[1])); }
           if (!gameHasPlatinum && !settings.nightMode) { tr.setAttribute('style', progressGoldBG(thisGameCompletion[1])); }
-        }
-        // 添加进度徽章
-        const gameText = tr.querySelector('td.pd10 > p > a');
-        if (gameText) {
-          const completion = thisGameCompletion[1];
-          const completionBadge = document.createElement('span');
-          completionBadge.className = 'completion-badge';
-          completionBadge.textContent = `${completion}%`;
-          completionBadge.title = '奖杯完成度';
-          gameText.parentNode.insertBefore(completionBadge, gameText);
+          // 添加进度徽章
+          const gameText = tr.querySelector('td.pd10 > p > a');
+          if (gameText) {
+            const completion = thisGameCompletion[1];
+            const completionBadge = document.createElement('span');
+            completionBadge.className = 'completion-badge';
+            completionBadge.textContent = `${completion}%`;
+            completionBadge.title = '奖杯完成度';
+            gameText.parentNode.insertBefore(completionBadge, gameText);
+          }
         }
       });
 

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -417,7 +417,7 @@
     */
     const hdElement = document.querySelector('.hd');
     if (hdElement && hdElement.textContent.trim() === '游戏列表') {
-      // 添加自定义的 CSS 类
+      // 添加徽章 CSS 类
       GM_addStyle(`
         span.completion-badge {
           background-color: rgb(5 96 175);
@@ -429,8 +429,7 @@
           font-weight: 300;
         }`);
 
-      // background-color: #d0f6ff;
-      // background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);
+      // 添加背景 CSS 类含夜间模式
       GM_addStyle(`
         tr.completed-platinum {
             /* background: rgba(200,255,250,0.6); */
@@ -443,9 +442,6 @@
             background-image: linear-gradient(90deg, rgba(200,255,250,0.15) 0%, rgba(200,255,250,0) 60%);
         }
       `);
-
-      // background-color: #e5ffe7;
-      // background-image: linear-gradient(90deg, #daffde 0 %, #ffffff 60 %);
       GM_addStyle(`
         tr.completed-gold {
             /* background: rgba(220,255,220,0.6); */
@@ -455,16 +451,14 @@
       GM_addStyle(`
         tr.completed-gold-night {
             /* background: rgba(101,159,19,0.1); */
-            background-image: linear-gradient(90deg, rgba(101,159,19,0.1) 0%, rgba(101,159,19,0) 60%);
+            background-image: linear-gradient(90deg, rgba(101,159,19,0.15) 0%, rgba(101,159,19,0) 60%);
         }
       `);
 
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
-      // 添加完成度染色
-      const personalGameCompletions = GM_getValue('personalGameCompletions', []);
-
       // 根据已保存的完成度添加染色
+      const personalGameCompletions = GM_getValue('personalGameCompletions', []);
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
@@ -488,13 +482,12 @@
         }
       });
 
-      // 创建新的 span 元素
+      // 添加按难度排列按钮
       const spanElement = document.createElement('span');
       spanElement.className = 'btn';
       spanElement.textContent = '按难度排列';
-      // 添加 span 元素到 .hd 元素中
+      // 添加 span 元素并设置样式
       hdElement.appendChild(spanElement);
-      // 添加样式使 span 右对齐
       const style = document.createElement('style');
       style.textContent = `
         .hd {
@@ -502,12 +495,7 @@
           justify-content: space-between;
           align-items: center;
         }
-        .hd span {
-          margin-top: 0px;
-        }
-        .btn {
-          cursor: pointer;
-        }
+        .hd span { margin-top: 0px; }
         `;
       document.head.appendChild(style);
 

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -417,11 +417,51 @@
     */
     const hdElement = document.querySelector('.hd');
     if (hdElement && hdElement.textContent.trim() === '游戏列表') {
+      // 添加自定义的 CSS 类
+      GM_addStyle(`
+        span.completion-badge {
+          background-color: rgb(5 96 175);
+          font-size: 11px;
+          color: white;
+          border-radius: 2px;
+          padding: 2px 6px;
+          margin-right: 4px;
+          font-weight: 300;
+        }`);
+
+      // background-color: #d0f6ff;
+      // background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);
+      GM_addStyle(`
+        tr.completed-platinum {
+            /* background: rgba(200,255,250,0.6); */
+            background-image: linear-gradient(90deg, rgba(200,255,250,0.8) 0%, rgba(200,255,250,0) 60%);
+        }
+      `);
+      GM_addStyle(`
+        tr.completed-platinum-night {
+            /* background: rgba(200,255,250,0.1); */
+            background-image: linear-gradient(90deg, rgba(200,255,250,0.15) 0%, rgba(200,255,250,0) 60%);
+        }
+      `);
+
+      // background-color: #e5ffe7;
+      // background-image: linear-gradient(90deg, #daffde 0 %, #ffffff 60 %);
+      GM_addStyle(`
+        tr.completed-gold {
+            /* background: rgba(220,255,220,0.6); */
+            background-image: linear-gradient(90deg, rgba(220,255,220,0.8) 0%, rgba(220,255,220,0) 60%);
+        }
+      `);
+      GM_addStyle(`
+        tr.completed-gold-night {
+            /* background: rgba(101,159,19,0.1); */
+            background-image: linear-gradient(90deg, rgba(101,159,19,0.1) 0%, rgba(101,159,19,0) 60%);
+        }
+      `);
+
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
       // 添加完成度染色
-      const platinumBackground = 'background-color: #d0f6ff;background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);';
-      const goldBackground = 'background-color: #e5ffe7;background-image: linear-gradient(90deg, #daffde 0%, #ffffff 60%);';
       const personalGameCompletions = GM_getValue('personalGameCompletions', []);
 
       // 根据已保存的完成度添加染色
@@ -429,8 +469,22 @@
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
         if (thisGameCompletion) {
-          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === true) { tr.setAttribute('style', platinumBackground); }
-          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === false) { tr.setAttribute('style', goldBackground); }
+          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === true) {
+            if (settings.nightMode) { tr.setAttribute('class', 'completed-platinum-night'); } else { tr.setAttribute('class', 'completed-platinum'); }
+          }
+          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === false) {
+            if (settings.nightMode) { tr.setAttribute('class', 'completed-gold-night'); } else { tr.setAttribute('class', 'completed-gold'); }
+          }
+          // 添加进度徽章
+          const gameText = tr.querySelector('td.pd10 > p > a');
+          if (gameText) {
+            const completion = thisGameCompletion[1];
+            const completionBadge = document.createElement('span');
+            completionBadge.className = 'completion-badge';
+            completionBadge.textContent = `${completion}%`;
+            completionBadge.title = '奖杯完成度';
+            gameText.parentNode.insertBefore(completionBadge, gameText);
+          }
         }
       });
 

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -397,7 +397,7 @@
         $('body,html').animate({
           scrollTop: document.body.clientHeight,
         },
-          500);
+        500);
       }).css({
         cursor: 'pointer',
       });
@@ -410,30 +410,29 @@
       document.head.appendChild(nightModeStyle);
     }
 
-    /* 
-      1.游戏列表添加按难度排列按钮 
+    /*
+      1.游戏列表添加按难度排列按钮
       2.游戏列表根据已记录的完成度添加染色
       3.TODO：游戏列表隐藏已经 100% 的游戏（需要添加用户可见的开关）
     */
     const hdElement = document.querySelector('.hd');
     if (hdElement && hdElement.textContent.trim() === '游戏列表') {
-
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
       // 添加完成度染色
-      const platinumBackground = 'background-color: #d0f6ff;background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);'
-      const goldBackground = 'background-color: #e5ffe7;background-image: linear-gradient(90deg, #daffde 0%, #ffffff 60%);'
-      const personalGameCompletions = GM_getValue('personalGameCompletions', [])
+      const platinumBackground = 'background-color: #d0f6ff;background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);';
+      const goldBackground = 'background-color: #e5ffe7;background-image: linear-gradient(90deg, #daffde 0%, #ffffff 60%);';
+      const personalGameCompletions = GM_getValue('personalGameCompletions', []);
 
       // 根据已保存的完成度添加染色
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
-        const thisGameCompletion = personalGameCompletions.find(item => item[0] == gameID);
+        const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
         if (thisGameCompletion) {
-          if (thisGameCompletion[1] == 100 && thisGameCompletion[2] == true) { tr.setAttribute('style', platinumBackground); }
-          if (thisGameCompletion[1] == 100 && thisGameCompletion[2] == false) { tr.setAttribute('style', goldBackground); }
+          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === true) { tr.setAttribute('style', platinumBackground); }
+          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === false) { tr.setAttribute('style', goldBackground); }
         }
-      })
+      });
 
       // 创建新的 span 元素
       const spanElement = document.createElement('span');
@@ -548,35 +547,34 @@
             }`,
     );
 
-    /* 
+    /*
       在 LocatStorage 中保存个人游戏完成度函数
       添加于 /psnid\/[A-Za-z0-9_-]+\/?$/ 页面，以及该页自动翻页函数内部
     */
 
     const savePersonalGameCompletions = (configifneeded) => {
-
       // if GM_setValue && GM_getValue is enabled
-      let thisFeatureEnabled = configifneeded || true && (typeof GM_setValue === 'function' && typeof GM_getValue === 'function')
+      const thisFeatureEnabled = (configifneeded || true) && (typeof GM_setValue === 'function' && typeof GM_getValue === 'function');
 
       if (thisFeatureEnabled) {
         // 获得当前页的游戏完成度
         const tdElements = document.querySelectorAll('table.list tbody > tr');
         const personalGameCompletions = Array.from(tdElements).map((tr) => {
-          const completionElement = tr.querySelector('div.progress > div')
-          const completion = completionElement ? parseFloat(completionElement.textContent) : 0
-          const platinumElement = tr.querySelector('span.text-platinum')
-          const platinum = platinumElement ? platinumElement.textContent == '白1' : false
-          const gameIDElement = tr.querySelector('a')
-          const gameID = gameIDElement.href.match(/\/psngame\/(\d+)/)[1]
-          return [gameID, completion, platinum]
-        })
+          const completionElement = tr.querySelector('div.progress > div');
+          const completion = completionElement ? parseFloat(completionElement.textContent) : 0;
+          const platinumElement = tr.querySelector('span.text-platinum');
+          const platinum = platinumElement ? platinumElement.textContent === '白1' : false;
+          const gameIDElement = tr.querySelector('a');
+          const gameID = gameIDElement.href.match(/\/psngame\/(\d+)/)[1];
+          return [gameID, completion, platinum];
+        });
 
         // 读取已保存的历史
-        let history = GM_getValue('personalGameCompletions', [])
+        const history = GM_getValue('personalGameCompletions', []);
 
         // 用当前覆盖历史
         personalGameCompletions.forEach((currentItem) => {
-          const index = history.findIndex(historyItem => historyItem[0] === currentItem[0]);
+          const index = history.findIndex((historyItem) => historyItem[0] === currentItem[0]);
           if (index !== -1) {
             history[index] = currentItem;
           } else {
@@ -587,19 +585,17 @@
         // 保存更新后的历史记录
         GM_setValue('personalGameCompletions', history);
         // console.log(GM_getValue('personalGameCompletions'))
-        return true
-      } else {
-        return false
+        return true;
       }
-    }
+      return false;
+    };
 
     // 在个人页面或个人游戏列表页更新数据
     if (
       /psnid\/[A-Za-z0-9_-]+\/?$/.test(window.location.href) || /psnid\/[A-Za-z0-9_-]+\/psngame\/?/.test(window.location.href)
     ) {
-      savePersonalGameCompletions()
+      savePersonalGameCompletions();
     }
-
 
     if (
       /psnid\/[A-Za-z0-9_-]+\/?$/.test(window.location.href)
@@ -635,7 +631,7 @@
                   gamePageIndex += 1;
 
                   // 同步更新个人游戏完成度
-                  savePersonalGameCompletions()
+                  savePersonalGameCompletions();
                 } else {
                   $('#loadingMessage').text('没有更多游戏了...');
                 }
@@ -962,7 +958,7 @@
             .append(`&nbsp;<a class="psnnode" id="hot" style="background-color: ${tagBackgroundColor === 'rgb(43, 43, 43)'
               ? 'rgb(125 69 67)' // 暗红色
               : 'rgb(217, 83, 79)' // 鲜红色
-              };color: rgb(255, 255, 255);">🔥热门&nbsp;</a>`);
+            };color: rgb(255, 255, 255);">🔥热门&nbsp;</a>`);
         }
       });
     };

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -435,6 +435,7 @@
       const progressGoldBG = (p) => `background-image: linear-gradient(90deg, rgba(220,255,220,0.8) ${p}%, rgba(220,255,220,0.15) ${p}%);`;
       const progressGoldBGNight = (p) => `background-image: linear-gradient(90deg, rgba(101,159,19,0.15) ${p}%, rgba(101,159,19,0.05) ${p}%);`;
 
+      // 获取游戏列表下所有游戏的 DOM 元素指针
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
       // 根据已保存的完成度添加染色
@@ -443,8 +444,8 @@
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
-        const gameHasPlatinum = tr.querySelector('td.pd10 > .meta > em.text-platinum').textContent === '白1';
         // if game hase platinum 由于个人页面的白金判断是记录的个人完成度，这里需要判断游戏本身是否有白金
+        const gameHasPlatinum = tr.querySelector('td.pd10 > .meta > em.text-platinum').textContent === '白1';
 
         if (thisGameCompletion) {
           if (gameHasPlatinum && settings.nightMode) { tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1])); }

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -429,31 +429,12 @@
           font-weight: 300;
         }`);
 
-      // 添加背景 CSS 类含夜间模式
-      GM_addStyle(`
-        tr.completed-platinum {
-            /* background: rgba(200,255,250,0.6); */
-            background-image: linear-gradient(90deg, rgba(200,255,250,0.8) 0%, rgba(200,255,250,0) 60%);
-        }
-      `);
-      GM_addStyle(`
-        tr.completed-platinum-night {
-            /* background: rgba(200,255,250,0.1); */
-            background-image: linear-gradient(90deg, rgba(200,255,250,0.15) 0%, rgba(200,255,250,0) 60%);
-        }
-      `);
-      GM_addStyle(`
-        tr.completed-gold {
-            /* background: rgba(220,255,220,0.6); */
-            background-image: linear-gradient(90deg, rgba(220,255,220,0.8) 0%, rgba(220,255,220,0) 60%);
-        }
-      `);
-      GM_addStyle(`
-        tr.completed-gold-night {
-            /* background: rgba(101,159,19,0.1); */
-            background-image: linear-gradient(90deg, rgba(101,159,19,0.15) 0%, rgba(101,159,19,0) 60%);
-        }
-      `);
+      // 背景 CSS 进度条计算，含夜间模式
+
+      const progressPlatinumBG = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.6) ${p}%, rgba(200,255,250,0.15) ${p}%)`;
+      const progressPlatinumBGNight = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.15) ${p}%, rgba(200,255,250,0.05) ${p}%)`;
+      const progressGoldBG = (p) => `background-image: linear-gradient(90deg, rgba(220,255,220,0.8) ${p}%, rgba(220,255,220,0.15) ${p}%);`;
+      const progressGoldBGNight = (p) => `background-image: linear-gradient(90deg, rgba(101,159,19,0.15) ${p}%, rgba(101,159,19,0.05) ${p}%);`;
 
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
@@ -463,11 +444,17 @@
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
         if (thisGameCompletion) {
-          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === true) {
-            if (settings.nightMode) { tr.setAttribute('class', 'completed-platinum-night'); } else { tr.setAttribute('class', 'completed-platinum'); }
-          }
-          if (thisGameCompletion[1] === 100 && thisGameCompletion[2] === false) {
-            if (settings.nightMode) { tr.setAttribute('class', 'completed-gold-night'); } else { tr.setAttribute('class', 'completed-gold'); }
+          // if game hase platinum
+          if (tr.querySelector('td.pd10 > .meta > em.text-platinum').textContent === '白1') {
+            if (settings.nightMode) {
+              tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1]));
+            } else {
+              tr.setAttribute('style', progressPlatinumBG(thisGameCompletion[1]));
+            }
+          } else if (settings.nightMode) {
+            tr.setAttribute('style', progressGoldBGNight(thisGameCompletion[1]));
+          } else {
+            tr.setAttribute('style', progressGoldBG(thisGameCompletion[1]));
           }
           // 添加进度徽章
           const gameText = tr.querySelector('td.pd10 > p > a');

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.23
+// @version      1.0.24
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -421,10 +421,11 @@
       const tdElements = document.querySelectorAll('table.list tbody > tr');
 
       // 添加完成度染色
-
       const platinumBackground = 'background-color: #d0f6ff;background-image: linear-gradient(90deg, #c7fffd 0%, #ffffff 60%);'
       const goldBackground = 'background-color: #e5ffe7;background-image: linear-gradient(90deg, #daffde 0%, #ffffff 60%);'
       const personalGameCompletions = GM_getValue('personalGameCompletions', [])
+
+      // 根据已保存的完成度添加染色
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find(item => item[0] == gameID);
@@ -433,7 +434,6 @@
           if (thisGameCompletion[1] == 100 && thisGameCompletion[2] == false) { tr.setAttribute('style', goldBackground); }
         }
       })
-
 
       // 创建新的 span 元素
       const spanElement = document.createElement('span');
@@ -557,11 +557,9 @@
     const savePersonalGameCompletions = (configifneeded) => {
 
       // if GM_setValue && GM_getValue is enabled
-
       let thisFeatureEnabled = configifneeded || true && (typeof GM_setValue === 'function' && typeof GM_getValue === 'function')
 
       if (thisFeatureEnabled) {
-
         // 获得当前页的游戏完成度
         const tdElements = document.querySelectorAll('table.list tbody > tr');
         const personalGameCompletions = Array.from(tdElements).map((tr) => {
@@ -571,7 +569,6 @@
           const platinum = platinumElement ? platinumElement.textContent == '白1' : false
           const gameIDElement = tr.querySelector('a')
           const gameID = gameIDElement.href.match(/\/psngame\/(\d+)/)[1]
-
           return [gameID, completion, platinum]
         })
 
@@ -590,7 +587,7 @@
 
         // 保存更新后的历史记录
         GM_setValue('personalGameCompletions', history);
-        console.log(GM_getValue('personalGameCompletions'))
+        // console.log(GM_getValue('personalGameCompletions'))
         return true
       } else {
         return false
@@ -603,7 +600,6 @@
     ) {
       savePersonalGameCompletions()
     }
-
 
 
     if (


### PR DESCRIPTION
在游列上添加个人游戏完成度的背景染色，效果如尾图：

代码中添加了两部分，

一部分是在个人页面更新游戏完成数据并添加到 GM_setValue 中的 savePersonalGameCompletions() 函数，该函数添加到了两处触发位置。

第二部分是在游戏列表中读取已保存数据并为对应游戏染底色。

其它行的变动为代码编辑器自行调整的缩进，我不知道怎么处理。// Update: lint used.

![@LQV%`AQ`Y6HHEINR0I2M(6](https://github.com/swsoyee/psnine-enhanced-version/assets/1635138/e9af5bb7-148e-43ff-8347-e6271e389a92)

