### PR TITLE
添加约战监控功能，以及在约战页显示非 100% 游戏的背景进度条

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psnine-enhanced-version",
-  "version": "1.0.24",
+  "version": "1.0.26",
   "description": "数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验",
   "main": "night-mode-css.js",
   "scripts": {

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.24
+// @version      1.0.25
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
@@ -88,6 +88,8 @@
     preferSearchForFindingVariants: false,
     // 展开隐藏的子评论
     expandCollapsedSubcomments: true,
+    // 约战页面显示相关游戏个人游戏进度
+    showGameProgressInBattle: true,
   };
   if (window.localStorage) {
     if (window.localStorage['psnine-night-mode-CSS-settings']) {
@@ -397,7 +399,7 @@
         $('body,html').animate({
           scrollTop: document.body.clientHeight,
         },
-        500);
+          500);
       }).css({
         cursor: 'pointer',
       });
@@ -413,7 +415,6 @@
     /*
       1.游戏列表添加按难度排列按钮
       2.游戏列表根据已记录的完成度添加染色
-      3.TODO：游戏列表隐藏已经 100% 的游戏（需要添加用户可见的开关）
     */
     const hdElement = document.querySelector('.hd');
     if (hdElement && hdElement.textContent.trim() === '游戏列表') {
@@ -436,11 +437,12 @@
       const progressGoldBGNight = (p) => `background-image: linear-gradient(90deg, rgba(101,159,19,0.15) ${p}%, rgba(101,159,19,0.05) ${p}%);`;
 
       // 获取游戏列表下所有游戏的 DOM 元素指针
-      const tdElements = document.querySelectorAll('table.list tbody > tr');
+      const tdElements = document.querySelectorAll('table.list > tbody > tr');
 
-      // 根据已保存的完成度添加染色
+      // 获取已保存的完成度
       const personalGameCompletions = GM_getValue('personalGameCompletions', []);
 
+      // 根据已保存的完成度添加染色
       tdElements.forEach((tr) => {
         const gameID = tr.getAttribute('id') || 0;
         const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
@@ -509,6 +511,28 @@
         // 切换排序顺序
         ascending = !ascending;
       });
+    }
+
+    /* 用背景进度条显示约战列表中，我有且未完美的游戏。 */
+    if (settings.showGameProgressInBattle) {
+      if (/battle$/.test(window.location.href)) {
+        const progressPlatinumBG = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.6) ${p}%, rgba(200,255,250,0.15) ${p}%)`;
+        const progressPlatinumBGNight = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.15) ${p}%, rgba(200,255,250,0.05) ${p}%)`;
+
+        const tdElements = document.querySelectorAll('table.list > tbody > tr');
+        const personalGameCompletions = GM_getValue('personalGameCompletions', []);
+
+        tdElements.forEach((tr) => {
+          const gameID = tr.querySelector('td.pdd15 a').href.match(/\/psngame\/(\d+)/)[1];
+          const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
+
+          if (thisGameCompletion && thisGameCompletion[1] < 100) {
+            // 约战页面没有显示游戏本身是否有白金，就直接默认以白金底色显示了
+            if (settings.nightMode) { tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1])); }
+            if (!settings.nightMode) { tr.setAttribute('style', progressPlatinumBG(thisGameCompletion[1])); }
+          }
+        });
+      }
     }
 
     /*
@@ -983,7 +1007,7 @@
             .append(`&nbsp;<a class="psnnode" id="hot" style="background-color: ${tagBackgroundColor === 'rgb(43, 43, 43)'
               ? 'rgb(125 69 67)' // 暗红色
               : 'rgb(217, 83, 79)' // 鲜红色
-            };color: rgb(255, 255, 255);">🔥热门&nbsp;</a>`);
+              };color: rgb(255, 255, 255);">🔥热门&nbsp;</a>`);
         }
       });
     };

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PSN中文网功能增强
 // @namespace    https://swsoyee.github.io
-// @version      1.0.25
+// @version      1.0.26
 // @description  数折价格走势图，显示人民币价格，奖杯统计和筛选，发帖字数统计和即时预览，楼主高亮，自动翻页，屏蔽黑名单用户发言，被@用户的发言内容显示等多项功能优化P9体验
 // eslint-disable-next-line max-len
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAMFBMVEVHcEw0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNs0mNuEOyNSAAAAD3RSTlMAQMAQ4PCApCBQcDBg0JD74B98AAABN0lEQVRIx+2WQRaDIAxECSACWLn/bdsCIkNQ2XXT2bTyHEx+glGIv4STU3KNRccp6dNh4qTM4VDLrGVRxbLGaa3ZQSVQulVJl5JFlh3cLdNyk/xe2IXz4DqYLhZ4mWtHd4/SLY/QQwKmWmGcmUfHb4O1mu8BIPGw4Hg1TEvySQGWoBcItgxndmsbhtJd6baukIKnt525W4anygNECVc1UD8uVbRNbumZNl6UmkagHeRJfX0BdM5NXgA+ZKESpiJ9tRFftZEvue2cS6cKOrGk/IOLTLUcaXuZHrZDq3FB2IonOBCHIy8Bs1Zzo1MxVH+m8fQ+nFeCQM3MWwEsWsy8e8Di7meA5Bb5MDYCt4SnUbP3lv1xOuWuOi3j5kJ5tPiZKahbi54anNRaaG7YElFKQBHR/9PjN3oD6fkt9WKF9rgAAAAASUVORK5CYII=
@@ -564,7 +564,7 @@
     let userBattleMonitors = GM_getValue('userBattleMonitors', []);
     let cacheBattleInfo = GM_getValue('cacheBattleInfo', {});
 
-    const updateTopMenuNotice = (lista, listb) => { // 定义函数：添加顶部菜单通知红点
+    const updateTopMenuNotice = (lista, listb) => { // 定义函数：变更顶部菜单通知红点
       let count = 0;
       lista.forEach((item) => {
         if (listb.includes(item)) count += 1;
@@ -609,6 +609,7 @@
       });
     };
 
+    // 页面加载时执行约战监测功能
     if (cacheBattleInfo.lastUpdate && new Date().getTime() - cacheBattleInfo.lastUpdate < settings.BattleInfoUpdateInterval) {
       updateTopMenuNotice(userBattleMonitors, cacheBattleInfo.list);
       console.log('use cached BattleRecuritInfo');
@@ -617,7 +618,7 @@
       console.log('update BattleRecuritInfo');
     }
 
-    // 添加约战监控按钮
+    // 在游戏的约战页面添加约战监控按钮
     if (/\/psngame\/\d+\/battle\/?$/.test(window.location.href)) {
       const gameID = window.location.href.match(/\/psngame\/(\d+)/)[1];
       const actionArea = document.querySelector('center.pd10');
@@ -638,8 +639,7 @@
           flex: 1;
           width: calc(50% - 8px);
           margin: 0 4px;
-        }
-        `;
+        }`;
       document.head.appendChild(style);
 
       // 为 span 元素添加点击事件，切换约战监控状态

--- a/psnineplus.js
+++ b/psnineplus.js
@@ -522,13 +522,12 @@
         const progressPlatinumBG = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.6) ${p}%, rgba(200,255,250,0.15) ${p}%)`;
         const progressPlatinumBGNight = (p) => `background-image: linear-gradient(90deg, rgba(200,240,255,0.15) ${p}%, rgba(200,255,250,0.05) ${p}%)`;
 
-        const tdElements = document.querySelectorAll('table.list > tbody > tr');
         const personalGameCompletions = GM_getValue('personalGameCompletions', []);
+        const tdElements = document.querySelectorAll('table.list > tbody > tr');
 
         tdElements.forEach((tr) => {
           const gameID = tr.querySelector('td.pdd15 a').href.match(/\/psngame\/(\d+)/)[1];
           const thisGameCompletion = personalGameCompletions.find((item) => item[0] === gameID);
-
           if (thisGameCompletion && thisGameCompletion[1] < 100) {
             // 约战页面没有显示游戏本身是否有白金，就直接默认白金底色显示了
             if (settings.nightMode) { tr.setAttribute('style', progressPlatinumBGNight(thisGameCompletion[1])); }
@@ -538,7 +537,11 @@
       }
     }
 
-    /* ↓↓↓ 约战监控与通知相关功能开始 ↓↓↓↓ */
+    /* ↓↓↓ 约战监控与通知相关功能开始 ↓↓↓↓
+        1. 用户是否设置了监控
+        2. 约战缓存是否存在或过期，否则从约战页更新数据
+        3. 比较两组数据，并更新顶部菜单
+    */
 
     // 添加消息通知数量图标样式（伪元素）
     GM_addStyle(`
@@ -558,13 +561,11 @@
       text-align: center;
     }`);
 
-    // 1. 用户是否设置了监控
-    // 2. 约战缓存是否存在或过期，否则从约战页更新数据
-    // 3. 比较两组数据，并更新顶部菜单
+    // 定义两个变量，用户设置的游戏约战监控列表，和当前存在的约战列表（缓存）
     let userBattleMonitors = GM_getValue('userBattleMonitors', []);
     let cacheBattleInfo = GM_getValue('cacheBattleInfo', {});
 
-    const updateTopMenuNotice = (lista, listb) => { // 定义函数：变更顶部菜单通知红点
+    const updateTopMenuNotice = (lista, listb) => { // 定义函数：变更顶部菜单通知红点，多处执行
       let count = 0;
       lista.forEach((item) => {
         if (listb.includes(item)) count += 1;
@@ -603,9 +604,7 @@
             updateTopMenuNotice(userBattleMonitors, cacheBattleInfo.list);
           }
         },
-        error: () => {
-          console.log('无法获取约战信息');
-        },
+        error: () => { console.log('无法获取约战信息'); },
       });
     };
 
@@ -624,7 +623,7 @@
       const actionArea = document.querySelector('center.pd10');
       const monitorBTN = document.createElement('p');
       monitorBTN.className = 'btn btn-large btn-info';
-      monitorBTN.title = '当有用户发起该游戏的约战时，你会收到消息通知。';
+      monitorBTN.title = '当有用户发起该游戏的约战时，顶部菜单会出现红点通知。';
       monitorBTN.textContent = userBattleMonitors.includes(gameID) ? '移除约战监控' : '添加约战监控';
       // 添加 span 元素并设置样式
       actionArea.appendChild(monitorBTN);


### PR DESCRIPTION
功能一：在约战页面添加了非 100% 游戏的奖杯进度背景进度条，与游列逻辑基本一致。

![AO`H)JGB2_KB0%ET5GCPW2T](https://github.com/user-attachments/assets/e7c7c807-b9c7-4d90-8276-0ea263ab6cc6)

功能二：约战监测
1. 在游戏的约战页添加约战监测按钮。
2. 当其它用户发起该游戏的约战邀请时，在顶部菜单栏显示红点通知。
3. 通过 ajax 更新约战页列表，由于目前只有一页，不确定存在多页时的更新办法。
4. 设置了 update interval 为一小时，在 settings 中添加了配置项，但没有提供给用户的编辑页面，也不打算提供。

![A6 NA B(QG~PLVEV~HKZ2ER](https://github.com/user-attachments/assets/d261673b-b668-4801-9425-551a06c46b6e)
